### PR TITLE
fix: Use crypto:mac/4 instead of deprecated hmac/3

### DIFF
--- a/src/jwerl_hs.erl
+++ b/src/jwerl_hs.erl
@@ -4,7 +4,7 @@
 -export([sign/3, verify/4]).
 
 sign(ShaBits, Key, Data) ->
-  crypto:hmac(algo(ShaBits), Key, Data).
+  crypto:mac(hmac, algo(ShaBits), Key, Data).
 
 verify(ShaBits, Key, Data, Signature) ->
   Signature == sign(ShaBits, Key, Data).


### PR DESCRIPTION
## About

`crypto:hmac/3` [was removed](http://erlang.org/doc/general_info/removed.html#functions-removed-in-otp-24) in OTP 24. `crypto:mac/4` should be used instead.

I tried to open a [PR against the upstream repo](https://github.com/G-Corp/jwerl/pull/21), but I don't think it's going to be merged. They've been [discussing this](https://gitlab.com/glejeune/jwerl/-/issues/18) for two months without any solution so far.